### PR TITLE
Implement draw compacting cross-platform

### DIFF
--- a/WolfEngine.Tests/MetalIndirectCompactionKernelTests.cs
+++ b/WolfEngine.Tests/MetalIndirectCompactionKernelTests.cs
@@ -1,0 +1,166 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using WolfEngine.Rendering;
+using WolfEngine.Rendering.Abstraction;
+
+namespace WolfEngine.Tests;
+
+/// <summary>
+/// Guards the hand-written Metal compaction kernel against the C# and Slang declarations it has to
+/// agree with.
+///
+/// gpu_draw_compact_icb.metal is the one shader in the engine that does not go through Slang: a Metal
+/// indirect command buffer is an opaque object, so its surviving commands are moved with the GPU-side
+/// copy_command intrinsic rather than copied as records. That means it re-declares the draw structs and
+/// the visibility flags by hand, and nothing in the build would notice them drifting - the kernel would
+/// simply read the wrong fields and compact the wrong draws, on Metal only, at runtime.
+/// </summary>
+[TestFixture]
+public class MetalIndirectCompactionKernelTests
+{
+	private const string SourceResourceName = "WolfEngine.Shaders.Metal.gpu_draw_compact_icb.metal";
+
+	[Test]
+	public void TheKernelSource_ShipsInsideTheAssembly()
+	{
+		Assert.That(ReadKernelSource(), Does.Contain("kernel void CSCompactIndirectCommands"));
+	}
+
+	[Test]
+	public void GpuDrawCommand_MatchesTheKernelsDeclaration()
+	{
+		AssertUintFieldsMatch<GpuDrawCommand>("GpuDrawCommand");
+	}
+
+	[Test]
+	public void GpuDrawArgs_MatchesTheKernelsDeclaration()
+	{
+		AssertUintFieldsMatch<GpuDrawArgs>("GpuDrawArgs");
+	}
+
+	[Test]
+	public void TheDrawFlagsTheKernelTests_MatchTheOnesTheEngineEncodes()
+	{
+		var source = ReadKernelSource();
+		Assert.Multiple(() =>
+		{
+			Assert.That(ReadUintConstant(source, "kDrawFlagActive"), Is.EqualTo(GpuDrawFlags.Active));
+			Assert.That(ReadUintConstant(source, "kDrawFlagBucketShift"), Is.EqualTo((uint)GpuDrawFlags.BucketShift));
+			Assert.That(ReadUintConstant(source, "kDrawFlagBucketMask"), Is.EqualTo(GpuDrawFlags.BucketMask));
+		});
+	}
+
+	/// <summary>
+	/// The visibility rules are shared with the record-copy kernel, so a change to one that misses the
+	/// other silently gives Metal and Direct3D12 different sets of visible draws.
+	/// </summary>
+	[Test]
+	public void TheVisibilityRules_StayInStepWithTheSharedRecordCopyKernel()
+	{
+		var slang = File.ReadAllText(Path.Combine(ResolveShaderDirectory(), "gpu_draw_compact.compute.slang"));
+		Assert.Multiple(() =>
+		{
+			Assert.That(ReadUintConstant(slang, "DRAW_FLAG_ACTIVE"), Is.EqualTo(GpuDrawFlags.Active));
+			Assert.That(ReadUintConstant(slang, "DRAW_FLAG_BUCKET_SHIFT"), Is.EqualTo((uint)GpuDrawFlags.BucketShift));
+			Assert.That(ReadUintConstant(slang, "DRAW_FLAG_BUCKET_MASK"), Is.EqualTo(GpuDrawFlags.BucketMask));
+		});
+	}
+
+	/// <summary>
+	/// Both kernels accumulate into the length half of a two-uint execution range, so the entry stride
+	/// the engine allocates and offsets by has to be the stride they index with.
+	/// </summary>
+	[Test]
+	public void BothKernels_IndexTheExecutionRangeTableWithTheSharedStride()
+	{
+		var entryUints = IndirectCompactionExecutionRange.StrideInBytes / sizeof(uint);
+		var lengthUintOffset = IndirectCompactionExecutionRange.LengthOffsetInBytes / sizeof(uint);
+
+		var slang = File.ReadAllText(Path.Combine(ResolveShaderDirectory(), "gpu_draw_compact.compute.slang"));
+		Assert.Multiple(() =>
+		{
+			Assert.That(
+				slang,
+				Does.Contain($"g_ExecutionRanges[(executionRangeIndex * {entryUints}) + {lengthUintOffset}]"),
+				"The record-copy kernel no longer indexes the execution range table with the shared stride.");
+			Assert.That(
+				ReadKernelSource(),
+				Does.Contain($"executionRanges[(params.executionRangeIndex * {entryUints}u) + {lengthUintOffset}u]"),
+				"The Metal kernel no longer indexes the execution range table with the shared stride.");
+		});
+	}
+
+	/// <summary>
+	/// Asserts that a struct of nothing but four-byte scalars is declared with the same fields, in the
+	/// same order, on both sides. Comparing sizes alone would let two fields swap unnoticed.
+	/// </summary>
+	private static void AssertUintFieldsMatch<T>(string kernelStructName) where T : struct
+	{
+		var kernelFields = ReadStructFieldNames(ReadKernelSource(), kernelStructName);
+		var managedFields = typeof(T)
+			.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+			.Select(field => field.Name.TrimStart('_'))
+			.ToArray();
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(
+				kernelFields.Select(name => name.ToLowerInvariant()),
+				Is.EqualTo(managedFields.Select(name => name.ToLowerInvariant())),
+				$"'{kernelStructName}' in the Metal kernel no longer declares the same fields as {typeof(T).Name}.");
+			Assert.That(
+				Marshal.SizeOf<T>(),
+				Is.EqualTo(kernelFields.Length * sizeof(uint)),
+				$"{typeof(T).Name} is no longer laid out as {kernelFields.Length} four-byte scalars.");
+		});
+	}
+
+	private static string[] ReadStructFieldNames(string source, string structName)
+	{
+		var body = Regex.Match(source, @"struct\s+" + Regex.Escape(structName) + @"\s*\{(?<body>[^}]*)\}");
+		Assert.That(body.Success, Is.True, $"'{structName}' is not declared in the kernel source.");
+
+		return Regex.Matches(body.Groups["body"].Value, @"(?:uint|int|float)\s+(?<name>\w+)\s*;")
+			.Select(match => match.Groups["name"].Value)
+			.ToArray();
+	}
+
+	private static uint ReadUintConstant(string source, string name)
+	{
+		var match = Regex.Match(source, Regex.Escape(name) + @"\s*=\s*(?<value>0[xX][0-9a-fA-F]+|\d+)u?\s*;");
+		Assert.That(match.Success, Is.True, $"'{name}' is not declared in the shader source.");
+
+		var value = match.Groups["value"].Value;
+		return value.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+			? Convert.ToUInt32(value[2..], 16)
+			: uint.Parse(value);
+	}
+
+	private static string ReadKernelSource()
+	{
+		using var stream = typeof(GpuDrawFlags).Assembly.GetManifestResourceStream(SourceResourceName);
+		Assert.That(stream, Is.Not.Null, $"'{SourceResourceName}' is not embedded in WolfEngine.");
+
+		using var reader = new StreamReader(stream!);
+		return reader.ReadToEnd();
+	}
+
+	private static string ResolveShaderDirectory()
+	{
+		var directory = new DirectoryInfo(AppContext.BaseDirectory);
+		while (directory is not null)
+		{
+			var candidate = Path.Combine(directory.FullName, "WolfEngine", "Shaders");
+			if (Directory.Exists(candidate))
+			{
+				return candidate;
+			}
+
+			directory = directory.Parent;
+		}
+
+		throw new DirectoryNotFoundException(
+			$"Could not locate WolfEngine/Shaders by walking up from '{AppContext.BaseDirectory}'.");
+	}
+}

--- a/WolfEngine/Rendering/Abstraction/GraphicsResources.cs
+++ b/WolfEngine/Rendering/Abstraction/GraphicsResources.cs
@@ -40,26 +40,60 @@ public interface IGfxPipeline : IGfxResource
 	PipelineKey Key { get; }
 }
 
+/// <summary>
+/// How a backend compacts an indirect command buffer down to the draws culling left visible, which
+/// is what lets execution stop scaling with the size of the scene rather than with what survived.
+/// </summary>
+public enum IndirectCompactionKind
+{
+	/// <summary>The backend cannot compact, so the caller executes the full command range instead.</summary>
+	None,
+
+	/// <summary>
+	/// Commands are plain records in a buffer, so a shared compute kernel copies the surviving records
+	/// from <see cref="IGfxIndirectCommandBuffer.TemplateRecordBuffer"/> into
+	/// <see cref="IGfxIndirectCommandBuffer.CompactedRecordBuffer"/>.
+	/// </summary>
+	CommandRecords,
+
+	/// <summary>
+	/// Commands are opaque objects that no shader can copy as memory, so the backend records the
+	/// compaction itself through <see cref="IGfxCommandList.RecordNativeIndirectCompaction"/>.
+	/// </summary>
+	NativeCommands
+}
+
+/// <summary>
+/// Layout of the entries compaction writes and the following execute reads: <c>{ location, length }</c>,
+/// which is an execution range Metal consumes whole. Compaction always emits from index zero, so
+/// location stays zero and backends that want only a count read the length field.
+/// </summary>
+public static class IndirectCompactionExecutionRange
+{
+	public const int StrideInBytes = 2 * sizeof(uint);
+
+	public const int LengthOffsetInBytes = sizeof(uint);
+}
+
 public interface IGfxIndirectCommandBuffer : IGfxResource
 {
 	IndirectCommandBufferDescriptor Descriptor { get; }
 
 	/// <summary>
-	/// True when the backend can execute a GPU-compacted subset of this buffer's commands, which lets
-	/// culling remove commands instead of leaving the command processor to walk every draw slot.
-	/// Backends that report false are executed through the full command range instead.
+	/// How this buffer's commands can be compacted, or <see cref="IndirectCompactionKind.None"/> when
+	/// the backend cannot, in which case it is executed through its full command range instead.
 	/// </summary>
-	bool SupportsGpuCompaction => false;
+	IndirectCompactionKind CompactionKind => IndirectCompactionKind.None;
 
 	/// <summary>
 	/// The CPU-encoded command records, readable by a compute shader as the compaction source.
-	/// Null when <see cref="SupportsGpuCompaction"/> is false.
+	/// Null unless <see cref="CompactionKind"/> is <see cref="IndirectCompactionKind.CommandRecords"/>.
 	/// </summary>
 	IGfxBuffer? TemplateRecordBuffer => null;
 
 	/// <summary>
 	/// The dense command records written by compaction and consumed by the following ExecuteIndirect.
-	/// Null when <see cref="SupportsGpuCompaction"/> is false.
+	/// Null unless <see cref="CompactionKind"/> is <see cref="IndirectCompactionKind.CommandRecords"/>.
 	/// </summary>
 	IGfxBuffer? CompactedRecordBuffer => null;
 

--- a/WolfEngine/Rendering/Abstraction/IGfxCommandList.cs
+++ b/WolfEngine/Rendering/Abstraction/IGfxCommandList.cs
@@ -17,6 +17,35 @@ public enum PrimitiveTopology
 }
 
 /// <summary>
+/// One page of commands to compact, for backends whose commands are opaque objects rather than
+/// records a shader can copy. The visibility rules are the engine's, so everything the shared
+/// compaction kernel tests is passed through here and the backend only owns the copy.
+/// </summary>
+/// <param name="ExecutionRangeIndex">
+/// Index of this page's <c>{ location, length }</c> entry in <paramref name="ExecutionRangeBuffer"/>.
+/// Compaction accumulates the length, which doubles as the allocator for dense destination slots.
+/// </param>
+/// <param name="DrawArgsBaseOffsetBytes">
+/// Byte offset of the view's slice of the draw args, so shadow cascades compact against their own
+/// visibility rather than the first cascade's.
+/// </param>
+/// <param name="LaneIndex">
+/// Execution lane that owns this page's draws. Every lane allocates a page over the same draw id
+/// range, so a draw is emitted only by the lane its bucket names.
+/// </param>
+public readonly record struct NativeIndirectCompactionRequest(
+	IGfxIndirectCommandBuffer CommandBuffer,
+	IGfxBuffer ExecutionRangeBuffer,
+	uint ExecutionRangeIndex,
+	IGfxBuffer DrawArgsBuffer,
+	ulong DrawArgsBaseOffsetBytes,
+	IGfxBuffer DrawCommandBuffer,
+	uint PageStartCommandIndex,
+	uint PageCommandCapacity,
+	uint LaneIndex,
+	uint ActiveDrawCommandUpperBound);
+
+/// <summary>
 /// API-neutral command list used by the render graph to encode graphics or compute work.
 /// </summary>
 public interface IGfxCommandList
@@ -81,14 +110,39 @@ public interface IGfxCommandList
 		ulong commandRangeOffsetBytes);
 
 	/// <summary>
-	/// Executes the compacted records of <paramref name="commandBuffer"/>, taking the command count
-	/// from GPU memory so culling decides how many commands the command processor walks.
-	/// Only valid when the buffer reports <see cref="IGfxIndirectCommandBuffer.SupportsGpuCompaction"/>.
+	/// Executes the compacted commands of <paramref name="commandBuffer"/>, taking how many to walk
+	/// from GPU memory so culling, not the size of the scene, decides the cost.
+	/// Only valid when the buffer's <see cref="IGfxIndirectCommandBuffer.CompactionKind"/> is not
+	/// <see cref="IndirectCompactionKind.None"/>.
 	/// </summary>
+	/// <param name="executionRangeOffsetBytes">
+	/// Offset of this page's entry in <paramref name="executionRangeBuffer"/>. Entries are two uints,
+	/// <c>{ location, length }</c>; compaction always emits from zero, so backends that want only a
+	/// count read the second uint.
+	/// </param>
 	void ExecuteCompactedIndirectCommandBuffer(
 		IGfxIndirectCommandBuffer commandBuffer,
-		IGfxBuffer countBuffer,
-		ulong countOffsetBytes);
+		IGfxBuffer executionRangeBuffer,
+		ulong executionRangeOffsetBytes);
+
+	/// <summary>
+	/// Records the GPU work that compacts one page of commands down to the draws culling left visible.
+	/// Only backends reporting <see cref="IndirectCompactionKind.NativeCommands"/> implement this; the
+	/// rest expose their command records instead and are compacted by the engine's shared kernel.
+	/// </summary>
+	void RecordNativeIndirectCompaction(in NativeIndirectCompactionRequest request) =>
+		throw new NotSupportedException(
+			$"{GetType().Name} does not record native indirect command compaction.");
+
+	/// <summary>
+	/// Zeroes the execution range table ahead of the compaction dispatches that accumulate into it.
+	/// Paired with <see cref="RecordNativeIndirectCompaction"/>, and separate from it because the table
+	/// is plain GPU memory that frames still in flight are reading: the reset has to be ordered on the
+	/// GPU timeline rather than written under them from the CPU.
+	/// </summary>
+	void ResetNativeIndirectCompactionRanges(IGfxBuffer executionRangeBuffer) =>
+		throw new NotSupportedException(
+			$"{GetType().Name} does not record native indirect command compaction.");
 
 	void BuildBottomLevelAccelerationStructure(IGfxBottomLevelAccelerationStructure accelerationStructure);
 

--- a/WolfEngine/Rendering/Backend/D3D12/D3D12CommandList.cs
+++ b/WolfEngine/Rendering/Backend/D3D12/D3D12CommandList.cs
@@ -910,8 +910,8 @@ internal unsafe class D3D12CommandList : IGfxCommandList, IDisposable
 
 	public void ExecuteCompactedIndirectCommandBuffer(
 		IGfxIndirectCommandBuffer commandBuffer,
-		IGfxBuffer countBuffer,
-		ulong countOffsetBytes)
+		IGfxBuffer executionRangeBuffer,
+		ulong executionRangeOffsetBytes)
 	{
 		if (commandBuffer is not D3D12IndirectCommandBuffer d3d12CommandBuffer)
 		{
@@ -924,9 +924,9 @@ internal unsafe class D3D12CommandList : IGfxCommandList, IDisposable
 				$"Indirect command buffer '{d3d12CommandBuffer.Name ?? "<unnamed>"}' does not support GPU compaction.");
 		}
 
-		if (countBuffer is not D3D12Buffer d3d12CountBuffer || d3d12CountBuffer.Resource.Handle is null)
+		if (executionRangeBuffer is not D3D12Buffer d3d12CountBuffer || d3d12CountBuffer.Resource.Handle is null)
 		{
-			throw new InvalidOperationException("Command count buffer was not created by the Direct3D12 backend.");
+			throw new InvalidOperationException("Command execution range buffer was not created by the Direct3D12 backend.");
 		}
 
 		var maxCommandCount = d3d12CommandBuffer.Descriptor.MaxCommandCount;
@@ -947,14 +947,15 @@ internal unsafe class D3D12CommandList : IGfxCommandList, IDisposable
 		TransitionBufferIfNeeded(d3d12CountBuffer, ResourceStates.IndirectArgument);
 
 		// D3D12 executes min(maxCommandCount, *countBuffer) commands, so the count written by
-		// compaction caps the walk at the visible draws.
+		// compaction caps the walk at the visible draws. Compacted records always start at index zero,
+		// which leaves the range entry's location field unused and the count in its length field.
 		CommandList.ExecuteIndirect(
 			d3d12CommandBuffer.CommandSignature,
 			maxCommandCount,
 			compactedBuffer.Resource,
 			0,
 			d3d12CountBuffer.Resource,
-			countOffsetBytes);
+			executionRangeOffsetBytes + IndirectCompactionExecutionRange.LengthOffsetInBytes);
 		TransitionBufferIfNeeded(d3d12CountBuffer, previousCountState);
 	}
 

--- a/WolfEngine/Rendering/Backend/D3D12/D3D12IndirectCommandBuffer.cs
+++ b/WolfEngine/Rendering/Backend/D3D12/D3D12IndirectCommandBuffer.cs
@@ -152,7 +152,8 @@ internal sealed unsafe class D3D12IndirectCommandBuffer : IGfxIndirectCommandBuf
 
 	internal ID3D12Resource* ArgumentBuffer => _argumentBuffer.Handle;
 
-	public bool SupportsGpuCompaction => _compactedBuffer is not null;
+	public IndirectCompactionKind CompactionKind =>
+		_compactedBuffer is null ? IndirectCompactionKind.None : IndirectCompactionKind.CommandRecords;
 
 	public IGfxBuffer? TemplateRecordBuffer => _templateView;
 

--- a/WolfEngine/Rendering/Backend/Metal/MetalCommandList.cs
+++ b/WolfEngine/Rendering/Backend/Metal/MetalCommandList.cs
@@ -17,6 +17,7 @@ internal sealed unsafe class MetalCommandList : IGfxCommandList, IDisposable
 {
 	private readonly MTLCommandQueue _queue;
 	private readonly MetalDescriptorTable _descriptorTable;
+	private readonly MetalIndirectCompactionKernel _indirectCompactionKernel;
 	private readonly MTLCommandBuffer _commandBuffer;
 	private MTLRenderCommandEncoder _renderEncoder;
 	private MTLComputeCommandEncoder _computeEncoder;
@@ -49,10 +50,14 @@ internal sealed unsafe class MetalCommandList : IGfxCommandList, IDisposable
 	private bool _gpuProfilingFailed;
 	private ulong _gpuFrameIndex;
 
-	public MetalCommandList(MTLCommandQueue queue, MetalDescriptorTable descriptorTable)
+	public MetalCommandList(
+		MTLCommandQueue queue,
+		MetalDescriptorTable descriptorTable,
+		MetalIndirectCompactionKernel indirectCompactionKernel)
 	{
 		_queue = queue;
 		_descriptorTable = descriptorTable;
+		_indirectCompactionKernel = indirectCompactionKernel;
 		_commandBuffer = _queue.CommandBuffer();
 	}
 
@@ -604,14 +609,167 @@ internal sealed unsafe class MetalCommandList : IGfxCommandList, IDisposable
 	}
 
 	/// <summary>
-	/// Metal indirect command buffers report no compaction support, so the shared draw passes keep
-	/// executing their full command range and never reach this path.
+	/// Executes the commands compaction left in the destination buffer. Metal reads the whole
+	/// <c>{ location, length }</c> entry as an execution range, so the count culling produced bounds the
+	/// walk without a round trip through the CPU.
 	/// </summary>
 	public void ExecuteCompactedIndirectCommandBuffer(
 		IGfxIndirectCommandBuffer commandBuffer,
-		IGfxBuffer countBuffer,
-		ulong countOffsetBytes) =>
-		throw new NotSupportedException("The Metal backend does not support compacted indirect command execution.");
+		IGfxBuffer executionRangeBuffer,
+		ulong executionRangeOffsetBytes)
+	{
+		ThrowIfDisposed();
+		if (commandBuffer is not MetalIndirectCommandBuffer metalCommandBuffer)
+		{
+			throw new InvalidOperationException("Indirect command buffer was not created by the Metal backend.");
+		}
+
+		if (metalCommandBuffer.CompactionKind != IndirectCompactionKind.NativeCommands)
+		{
+			throw new InvalidOperationException(
+				$"Indirect command buffer '{metalCommandBuffer.Name ?? "<unnamed>"}' does not support GPU compaction.");
+		}
+
+		if (executionRangeBuffer is not MetalBuffer metalRangeBuffer)
+		{
+			throw new InvalidOperationException("Command execution range buffer was not created by the Metal backend.");
+		}
+		if (metalRangeBuffer.IsDisposed)
+		{
+			return;
+		}
+		if (metalCommandBuffer.UsesCurrentBindlessBuffers(
+			    _descriptorTable,
+			    metalCommandBuffer.Descriptor.MaxCommandCount) == false)
+		{
+			return;
+		}
+
+		EnsureRenderEncoder();
+
+		// The compacted commands are copies, so they bind exactly the buffers the encoded commands do and
+		// the template's reference list is the right residency set for them.
+		var referenced = metalCommandBuffer.GetReferencedBuffers();
+		for (var i = 0; i < referenced.Count; i++)
+		{
+			_renderEncoder.UseResource(referenced[i], MTLResourceUsage.Read);
+		}
+
+		_renderEncoder.UseResource(metalRangeBuffer.Buffer, MTLResourceUsage.Read);
+		_renderEncoder.ExecuteCommandsInBuffer(
+			metalCommandBuffer.CompactedBuffer,
+			metalRangeBuffer.Buffer,
+			(nuint)executionRangeOffsetBytes);
+	}
+
+	/// <summary>
+	/// Clears the execution range table with a blit fill, which puts the reset on the same timeline as
+	/// the dispatches that follow and, unlike a CPU write into shared storage, cannot land underneath a
+	/// frame that has not retired yet.
+	/// </summary>
+	public void ResetNativeIndirectCompactionRanges(IGfxBuffer executionRangeBuffer)
+	{
+		ThrowIfDisposed();
+		if (executionRangeBuffer is not MetalBuffer metalBuffer)
+		{
+			throw new InvalidOperationException("Command execution range buffer was not created by the Metal backend.");
+		}
+		if (metalBuffer.IsDisposed)
+		{
+			return;
+		}
+
+		EndActiveEncoders();
+		var blit = _commandBuffer.BlitCommandEncoder();
+		blit.FillBuffer(metalBuffer.Buffer, new NSRange { location = 0, length = metalBuffer.Buffer.Length }, 0);
+		blit.EndEncoding();
+		if (blit.NativePtr != IntPtr.Zero)
+		{
+			blit.Dispose();
+		}
+	}
+
+	/// <summary>
+	/// Dispatches the kernel that copies a page's visible commands into its compacted buffer. Metal
+	/// commands are opaque objects rather than records in memory, so only the backend can move them.
+	/// </summary>
+	public void RecordNativeIndirectCompaction(in NativeIndirectCompactionRequest request)
+	{
+		ThrowIfDisposed();
+		if (request.CommandBuffer is not MetalIndirectCommandBuffer metalCommandBuffer)
+		{
+			throw new InvalidOperationException("Indirect command buffer was not created by the Metal backend.");
+		}
+
+		if (metalCommandBuffer.CompactionKind != IndirectCompactionKind.NativeCommands)
+		{
+			throw new InvalidOperationException(
+				$"Indirect command buffer '{metalCommandBuffer.Name ?? "<unnamed>"}' does not support GPU compaction.");
+		}
+
+		if (request.ExecutionRangeBuffer is not MetalBuffer executionRangeBuffer ||
+		    request.DrawArgsBuffer is not MetalBuffer drawArgsBuffer ||
+		    request.DrawCommandBuffer is not MetalBuffer drawCommandBuffer)
+		{
+			throw new InvalidOperationException("Compaction input buffers were not created by the Metal backend.");
+		}
+
+		if (executionRangeBuffer.IsDisposed || drawArgsBuffer.IsDisposed || drawCommandBuffer.IsDisposed)
+		{
+			return;
+		}
+
+		EnsureComputeEncoder();
+
+		// This kernel belongs to the backend and has no MetalPipeline wrapper, so setting it directly
+		// leaves the cached compute bindings describing state that is no longer bound. Clearing them makes
+		// the next BindPipeline re-establish everything rather than trust the cache.
+		_computeEncoder.SetComputePipelineState(_indirectCompactionKernel.PipelineState);
+		_currentComputePipeline = null;
+		_bindlessBuffersSetCompute = false;
+		_lastBindlessVersionCompute = uint.MaxValue;
+
+		_computeEncoder.SetBuffer(
+			metalCommandBuffer.CompactionArguments,
+			0,
+			MetalIndirectCompactionKernel.CommandBuffersBufferIndex);
+		// The two command buffers are reached through the argument buffer, so residency for them has to be
+		// declared here rather than inferred from the bindings.
+		_computeEncoder.UseResource(metalCommandBuffer.Buffer, MTLResourceUsage.Read);
+		_computeEncoder.UseResource(metalCommandBuffer.CompactedBuffer, MTLResourceUsage.Write);
+
+		_computeEncoder.SetBuffer(
+			executionRangeBuffer.Buffer,
+			0,
+			MetalIndirectCompactionKernel.ExecutionRangeBufferIndex);
+		_computeEncoder.SetBuffer(
+			drawArgsBuffer.Buffer,
+			(nuint)request.DrawArgsBaseOffsetBytes,
+			MetalIndirectCompactionKernel.DrawArgsBufferIndex);
+		_computeEncoder.SetBuffer(
+			drawCommandBuffer.Buffer,
+			0,
+			MetalIndirectCompactionKernel.DrawCommandsBufferIndex);
+
+		var parameters = new MetalIndirectCompactionParams
+		{
+			PageStartCommandIndex = request.PageStartCommandIndex,
+			PageCommandCapacity = request.PageCommandCapacity,
+			LaneIndex = request.LaneIndex,
+			ExecutionRangeIndex = request.ExecutionRangeIndex,
+			ActiveDrawCommandUpperBound = request.ActiveDrawCommandUpperBound
+		};
+		_computeEncoder.SetBytes(
+			(IntPtr)(&parameters),
+			(nuint)sizeof(MetalIndirectCompactionParams),
+			MetalIndirectCompactionKernel.ParamsBufferIndex);
+
+		var threadsPerThreadgroup = MetalIndirectCompactionKernel.ThreadsPerThreadgroup;
+		var threadgroupCount = (request.PageCommandCapacity + threadsPerThreadgroup - 1) / threadsPerThreadgroup;
+		_computeEncoder.DispatchThreadgroups(
+			new MTLSize { width = threadgroupCount, height = 1, depth = 1 },
+			new MTLSize { width = threadsPerThreadgroup, height = 1, depth = 1 });
+	}
 
 	public void ExecuteIndirectCommandBufferRange(
 		IGfxIndirectCommandBuffer commandBuffer,

--- a/WolfEngine/Rendering/Backend/Metal/MetalDevice.cs
+++ b/WolfEngine/Rendering/Backend/Metal/MetalDevice.cs
@@ -56,6 +56,7 @@ internal sealed class MetalDevice : IGfxDevice, ITexturePoolDevice, IGpuSubmissi
 	private readonly MTLCommandQueue _commandQueue;
 	private readonly MetalDescriptorTable _descriptorTable;
 	private readonly MetalGpuProfilerBackend _gpuProfilerBackend;
+	private readonly MetalIndirectCompactionKernel _indirectCompactionKernel;
 	private readonly GpuRetirementQueue _retirementQueue = new();
 	private readonly object _retirementTokenOwner = new();
 	private readonly Dictionary<PipelineKey, MetalPipeline> _pipelines = new();
@@ -90,6 +91,7 @@ internal sealed class MetalDevice : IGfxDevice, ITexturePoolDevice, IGpuSubmissi
 		}
 		_descriptorTable = new MetalDescriptorTable(_device, RetireArgumentBuffer);
 		_gpuProfilerBackend = new MetalGpuProfilerBackend(_device);
+		_indirectCompactionKernel = new MetalIndirectCompactionKernel(_device);
 		_metallibCacheDirectory = Path.Combine(Path.GetTempPath(), "WolfEngine", "metallib-cache");
 		Directory.CreateDirectory(_metallibCacheDirectory);
 	}
@@ -136,12 +138,12 @@ internal sealed class MetalDevice : IGfxDevice, ITexturePoolDevice, IGpuSubmissi
 
 	public IGfxCommandList BeginGraphics()
 	{
-		return new MetalCommandList(_commandQueue, _descriptorTable);
+		return new MetalCommandList(_commandQueue, _descriptorTable, _indirectCompactionKernel);
 	}
 
 	public IGfxCommandList BeginCompute()
 	{
-		return new MetalCommandList(_commandQueue, _descriptorTable);
+		return new MetalCommandList(_commandQueue, _descriptorTable, _indirectCompactionKernel);
 	}
 
 	public void WaitForIdle()
@@ -424,7 +426,31 @@ internal sealed class MetalDevice : IGfxDevice, ITexturePoolDevice, IGpuSubmissi
 			}
 
 			commandBuffer.Reset(new NSRange { location = 0, length = descriptor.MaxCommandCount });
-			return new MetalIndirectCommandBuffer(null, descriptor, commandBuffer);
+
+			// The compaction destination is built from the same descriptor, which is what makes the two
+			// buffers' commands copyable into one another. Without the kernel there is nothing to write it,
+			// so the page reports no compaction support and the shared draw passes execute the full range.
+			var compactedBuffer = default(MTLIndirectCommandBuffer);
+			var compactionArguments = default(MTLBuffer);
+			if (_indirectCompactionKernel.IsAvailable)
+			{
+				compactedBuffer = _device.NewIndirectCommandBuffer(
+					indirectDescriptor,
+					descriptor.MaxCommandCount,
+					MTLResourceOptions.ResourceStorageModeShared);
+				if (compactedBuffer.NativePtr != IntPtr.Zero)
+				{
+					compactedBuffer.Reset(new NSRange { location = 0, length = descriptor.MaxCommandCount });
+					compactionArguments = _indirectCompactionKernel.CreateArgumentBuffer(commandBuffer, compactedBuffer);
+				}
+			}
+
+			return new MetalIndirectCommandBuffer(
+				descriptor.Name,
+				descriptor,
+				commandBuffer,
+				compactedBuffer,
+				compactionArguments);
 		}
 		finally
 		{

--- a/WolfEngine/Rendering/Backend/Metal/MetalIndirectCommandBuffer.cs
+++ b/WolfEngine/Rendering/Backend/Metal/MetalIndirectCommandBuffer.cs
@@ -93,11 +93,18 @@ internal sealed class MetalIndirectCommandBuffer : IGfxIndirectCommandBuffer, ID
 		public MTLBuffer BindlessSamplerBuffer { get; }
 	}
 
-	public MetalIndirectCommandBuffer(string? name, in IndirectCommandBufferDescriptor descriptor, MTLIndirectCommandBuffer buffer)
+	public MetalIndirectCommandBuffer(
+		string? name,
+		in IndirectCommandBufferDescriptor descriptor,
+		MTLIndirectCommandBuffer buffer,
+		MTLIndirectCommandBuffer compactedBuffer = default,
+		MTLBuffer compactionArguments = default)
 	{
 		Name = name;
 		Descriptor = descriptor;
 		Buffer = buffer;
+		CompactedBuffer = compactedBuffer;
+		CompactionArguments = compactionArguments;
 	}
 
 	public string? Name { get; }
@@ -105,6 +112,24 @@ internal sealed class MetalIndirectCommandBuffer : IGfxIndirectCommandBuffer, ID
 	public IndirectCommandBufferDescriptor Descriptor { get; }
 
 	internal MTLIndirectCommandBuffer Buffer { get; }
+
+	/// <summary>
+	/// Destination for the commands culling leaves visible, holding them densely from index zero so the
+	/// execute walks only what survived. Null-valued when the compaction kernel is unavailable.
+	/// </summary>
+	internal MTLIndirectCommandBuffer CompactedBuffer { get; }
+
+	/// <summary>
+	/// Argument buffer naming <see cref="Buffer"/> and <see cref="CompactedBuffer"/> to the compaction
+	/// kernel. Metal cannot bind an indirect command buffer to a compute encoder any other way, and the
+	/// pair never changes, so it is built once with the page.
+	/// </summary>
+	internal MTLBuffer CompactionArguments { get; }
+
+	public IndirectCompactionKind CompactionKind =>
+		CompactedBuffer.NativePtr != IntPtr.Zero && CompactionArguments.NativePtr != IntPtr.Zero
+			? IndirectCompactionKind.NativeCommands
+			: IndirectCompactionKind.None;
 
 	public void ResetCommand(uint commandIndex)
 	{
@@ -307,6 +332,16 @@ internal sealed class MetalIndirectCommandBuffer : IGfxIndirectCommandBuffer, ID
 		if (Buffer.NativePtr != IntPtr.Zero)
 		{
 			Buffer.Dispose();
+		}
+
+		if (CompactedBuffer.NativePtr != IntPtr.Zero)
+		{
+			CompactedBuffer.Dispose();
+		}
+
+		if (CompactionArguments.NativePtr != IntPtr.Zero)
+		{
+			CompactionArguments.Dispose();
 		}
 	}
 

--- a/WolfEngine/Rendering/Backend/Metal/MetalIndirectCompactionKernel.cs
+++ b/WolfEngine/Rendering/Backend/Metal/MetalIndirectCompactionKernel.cs
@@ -1,0 +1,226 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using SharpMetal.Foundation;
+using SharpMetal.Metal;
+using WolfEngine.Platform;
+
+namespace WolfEngine.Rendering.Backend.Metal;
+
+/// <summary>
+/// Owns the compute kernel that compacts an indirect command buffer page down to the draws culling
+/// left visible.
+///
+/// The kernel is hand-written MSL rather than a Slang program like the rest of the engine's shaders:
+/// a Metal indirect command buffer is an opaque object, not a buffer of command records, so moving a
+/// surviving command means calling the GPU-side <c>copy_command</c> intrinsic, which the shared shader
+/// language cannot express. It is compiled on demand so that a device or OS without the intrinsic
+/// reports itself unavailable and leaves the shared draw passes on their full-range fallback.
+/// </summary>
+[SupportedOSPlatform("macos")]
+internal sealed class MetalIndirectCompactionKernel : IDisposable
+{
+	public const uint ThreadsPerThreadgroup = 64;
+
+	public const uint CommandBuffersBufferIndex = 0;
+	public const uint ExecutionRangeBufferIndex = 1;
+	public const uint DrawArgsBufferIndex = 2;
+	public const uint DrawCommandsBufferIndex = 3;
+	public const uint ParamsBufferIndex = 4;
+
+	private const string EntryPoint = "CSCompactIndirectCommands";
+	private const string SourceResourceName = "WolfEngine.Shaders.Metal.gpu_draw_compact_icb.metal";
+	private const ulong SourceCommandBufferArgumentIndex = 0;
+	private const ulong DestinationCommandBufferArgumentIndex = 1;
+
+	private readonly MTLDevice _device;
+	private readonly object _compileSync = new();
+	private MTLLibrary _library;
+	private MTLFunction _function;
+	private MTLArgumentEncoder _argumentEncoder;
+	private MTLComputePipelineState _pipelineState;
+	private bool _compileAttempted;
+	private string? _unavailableReason;
+	private bool _disposed;
+
+	public MetalIndirectCompactionKernel(MTLDevice device)
+	{
+		_device = device;
+	}
+
+	public bool IsAvailable => TryCompile();
+
+	/// <summary>Why compaction is unavailable, or null while it has not been asked for or is working.</summary>
+	public string? UnavailableReason => _unavailableReason;
+
+	internal MTLComputePipelineState PipelineState => _pipelineState;
+
+	/// <summary>
+	/// Builds the argument buffer the kernel reads its two command buffers through. Metal has no way to
+	/// bind an indirect command buffer directly to a compute encoder, so the pair travels in an argument
+	/// buffer, which is fixed for the lifetime of the page and worth building once.
+	/// </summary>
+	public MTLBuffer CreateArgumentBuffer(
+		MTLIndirectCommandBuffer source,
+		MTLIndirectCommandBuffer destination)
+	{
+		if (TryCompile() == false)
+		{
+			return default;
+		}
+
+		var argumentBuffer = _device.NewBuffer(
+			_argumentEncoder.EncodedLength,
+			MTLResourceOptions.ResourceStorageModeShared);
+		if (argumentBuffer.NativePtr == IntPtr.Zero)
+		{
+			return default;
+		}
+
+		_argumentEncoder.SetArgumentBuffer(argumentBuffer, 0);
+		_argumentEncoder.SetIndirectCommandBuffer(source, SourceCommandBufferArgumentIndex);
+		_argumentEncoder.SetIndirectCommandBuffer(destination, DestinationCommandBufferArgumentIndex);
+		return argumentBuffer;
+	}
+
+	private bool TryCompile()
+	{
+		lock (_compileSync)
+		{
+			if (_compileAttempted)
+			{
+				return _unavailableReason is null;
+			}
+
+			_compileAttempted = true;
+			try
+			{
+				CompileLocked();
+			}
+			catch (Exception exception)
+			{
+				_unavailableReason = exception.Message;
+				ReleaseLocked();
+			}
+
+			return _unavailableReason is null;
+		}
+	}
+
+	private void CompileLocked()
+	{
+		using var source = NSStringHelper.From(ReadSource());
+		using var options = new MTLCompileOptions
+		{
+			// copy_command needs a language version that has GPU-side command encoding; pinning it keeps
+			// the kernel off whatever default the running toolchain happens to pick.
+			LanguageVersion = MTLLanguageVersion.Version30
+		};
+
+		var libraryError = new NSError(IntPtr.Zero);
+		_library = _device.NewLibrary(source, options, ref libraryError);
+		if (_library.NativePtr == IntPtr.Zero)
+		{
+			throw new InvalidOperationException(
+				$"Failed to compile the Metal indirect command compaction kernel: {DescribeError(libraryError)}");
+		}
+
+		using var entryPoint = NSStringHelper.From(EntryPoint);
+		_function = _library.NewFunction(entryPoint);
+		if (_function.NativePtr == IntPtr.Zero)
+		{
+			throw new InvalidOperationException(
+				$"The Metal indirect command compaction library does not define '{EntryPoint}'.");
+		}
+
+		var pipelineError = new NSError(IntPtr.Zero);
+		_pipelineState = _device.NewComputePipelineState(_function, ref pipelineError);
+		if (_pipelineState.NativePtr == IntPtr.Zero)
+		{
+			throw new InvalidOperationException(
+				$"Failed to create the Metal indirect command compaction pipeline state: {DescribeError(pipelineError)}");
+		}
+
+		_argumentEncoder = _function.NewArgumentEncoder(CommandBuffersBufferIndex);
+		if (_argumentEncoder.NativePtr == IntPtr.Zero)
+		{
+			throw new InvalidOperationException(
+				"The Metal indirect command compaction kernel did not expose an argument encoder for its command buffers.");
+		}
+	}
+
+	private static string ReadSource()
+	{
+		using var stream = typeof(MetalIndirectCompactionKernel).Assembly
+			                   .GetManifestResourceStream(SourceResourceName)
+		                   ?? throw new InvalidOperationException(
+			                   $"The embedded Metal compaction shader '{SourceResourceName}' is missing from the assembly.");
+		using var reader = new StreamReader(stream);
+		return reader.ReadToEnd();
+	}
+
+	private static string DescribeError(NSError error) =>
+		error.NativePtr == IntPtr.Zero
+			? "Unknown Metal error."
+			: error.LocalizedDescription.ToManagedString("Unknown Metal error.");
+
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		lock (_compileSync)
+		{
+			ReleaseLocked();
+		}
+
+		_disposed = true;
+	}
+
+	private void ReleaseLocked()
+	{
+		if (_argumentEncoder.NativePtr != IntPtr.Zero)
+		{
+			_argumentEncoder.Dispose();
+			_argumentEncoder = default;
+		}
+
+		if (_pipelineState.NativePtr != IntPtr.Zero)
+		{
+			_pipelineState.Dispose();
+			_pipelineState = default;
+		}
+
+		if (_function.NativePtr != IntPtr.Zero)
+		{
+			_function.Dispose();
+			_function = default;
+		}
+
+		if (_library.NativePtr != IntPtr.Zero)
+		{
+			_library.Dispose();
+			_library = default;
+		}
+	}
+}
+
+/// <summary>
+/// Per-page inputs to <c>CSCompactIndirectCommands</c>. Mirrors <c>CompactionParams</c> in
+/// gpu_draw_compact_icb.metal.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct MetalIndirectCompactionParams
+{
+	public uint PageStartCommandIndex;
+	public uint PageCommandCapacity;
+	public uint LaneIndex;
+	public uint ExecutionRangeIndex;
+	public uint ActiveDrawCommandUpperBound;
+}

--- a/WolfEngine/Rendering/Passes/GBufferPass.cs
+++ b/WolfEngine/Rendering/Passes/GBufferPass.cs
@@ -97,12 +97,12 @@ public static class GBufferPass
 				{
 					commandList.BindConstantBuffer(bucket.BufferBindings.MaterialGenerationRegisterIndex, config.MaterialGenerationBuffer);
 				}
-				if (config.CompactedCommandCountBuffer is { } countBuffer)
+				if (config.CompactedExecutionRangeBuffer is { } executionRangeBuffer)
 				{
 					SharedDrawIndirectExecution.ExecuteCompactedPages(
 						commandList,
 						bucket.IndirectCommandPages.Span,
-						countBuffer,
+						executionRangeBuffer,
 						config.IndirectCommandSlot,
 						bucket.ExecutionIndex,
 						config.FallbackMaxCommandCount);

--- a/WolfEngine/Rendering/Passes/GBufferPassConfig.cs
+++ b/WolfEngine/Rendering/Passes/GBufferPassConfig.cs
@@ -112,5 +112,5 @@ public struct GBufferPassConfig
 	/// Per-page compacted command counts when compaction ran this frame, otherwise null, which selects
 	/// the full-range execution path.
 	/// </summary>
-	public IGfxBuffer? CompactedCommandCountBuffer { get; set; }
+	public IGfxBuffer? CompactedExecutionRangeBuffer { get; set; }
 }

--- a/WolfEngine/Rendering/Passes/GpuDrawPass.cs
+++ b/WolfEngine/Rendering/Passes/GpuDrawPass.cs
@@ -41,6 +41,7 @@ public sealed class GpuDrawPass
 	private ComputeThreadGroupSize? _terrainLayerUpdateThreadGroupSize;
 	private ComputeThreadGroupSize? _cullThreadGroupSize;
 	private ComputeThreadGroupSize? _compactThreadGroupSize;
+	private uint[]? _executionRangeReset;
 	private ComputeResourceBindings? _terrainMaterialUpdateBindings;
 	private ComputeResourceBindings? _terrainLayerUpdateBindings;
 	private ShaderPropertyWriter? _instanceUpdateParamsWriter;
@@ -1095,7 +1096,7 @@ public sealed class GpuDrawPass
 		ArgumentNullException.ThrowIfNull(laneAvailable);
 
 		if (drawArgsBuffer is null ||
-		    _gpuDrawResources.DrawCommandBuffer is null ||
+		    _gpuDrawResources.DrawCommandBuffer is not { } drawCommandBuffer ||
 		    _supportsIndirectStructuralUpdates == false)
 		{
 			return false;
@@ -1103,37 +1104,46 @@ public sealed class GpuDrawPass
 
 		var device = _renderer.GetGfxDevice();
 		commandSet.EnsureCreated(device);
-		var countBuffer = commandSet.CompactedCommandCountBuffer;
-		if (countBuffer is null)
+		var executionRangeBuffer = commandSet.CompactedExecutionRangeBuffer;
+		if (executionRangeBuffer is null)
 		{
 			return false;
 		}
 
 		var activeSlot = _gpuDrawResources.ActiveIndirectCommandSlot;
 		var laneDefinitions = GpuDrawExecutionLanes.GetDefinitionsForPass(participation);
-		if (SupportsCompaction(commandSet, activeSlot, laneDefinitions, laneAvailable) == false)
+		if (ResolveCompactionKind(commandSet, activeSlot, laneDefinitions, laneAvailable) is not { } compactionKind)
+		{
+			// Nothing has been encoded for this pass yet, so there is nothing to compact and nothing to
+			// say about it. Executing the empty full range costs the same as executing an empty compaction.
+			return false;
+		}
+
+		if (compactionKind == IndirectCompactionKind.None)
 		{
 			LogCompactionUnavailableOnce(participation);
 			return false;
 		}
 
-		// Zeroing through the CPU-writable path stages an upload copy, and that copy's transition back
-		// to UnorderedAccess is what orders the reset ahead of the compaction dispatch below.
-		Span<uint> resetCounts = stackalloc uint[SharedDrawIndirectCommandSet.CompactedCommandCountEntryCount];
-		resetCounts.Clear();
-		WriteBuffer<uint>(countBuffer, resetCounts, "SharedDrawCompactedCommandCounts");
-
-		var pipeline = EnsureCompactPipeline(device);
 		var commandList = context.CommandList;
 		using (FrameProfiler.Instance.Measure("GpuDraw.Compact"))
 		{
-			commandList.BindPipeline(pipeline);
-			var compactParamsWriter = _compactParamsWriter
-			                          ?? throw new InvalidOperationException(
-				                          "GpuDraw compaction reflection writer was not initialized.");
-			var threadGroupSize = _compactThreadGroupSize
-			                      ?? throw new InvalidOperationException(
-				                      "GpuDraw compaction threadgroup size was not initialized.");
+			// Both resets leave every range's location field at the zero compaction emits from, and both
+			// have to land ahead of the dispatches below. The record-copy path gets that from the upload
+			// copy its CPU write stages, whose transition back to UnorderedAccess orders it; the native
+			// path has no such copy, so the backend clears the table on the GPU timeline instead.
+			if (compactionKind == IndirectCompactionKind.CommandRecords)
+			{
+				WriteBuffer<uint>(
+					executionRangeBuffer,
+					RentExecutionRangeReset(),
+					"SharedDrawCompactedExecutionRanges");
+				commandList.BindPipeline(EnsureCompactPipeline(device));
+			}
+			else
+			{
+				commandList.ResetNativeIndirectCompactionRanges(executionRangeBuffer);
+			}
 
 			for (var i = 0; i < laneDefinitions.Length; i++)
 			{
@@ -1152,41 +1162,29 @@ public sealed class GpuDrawPass
 						continue;
 					}
 
-					var templateBuffer = page.CommandBuffer.TemplateRecordBuffer;
-					var compactedBuffer = page.CommandBuffer.CompactedRecordBuffer;
-					if (templateBuffer is null || compactedBuffer is null)
-					{
-						continue;
-					}
-
-					var countIndex = SharedDrawIndirectCommandSet.GetCompactedCommandCountIndex(
+					var rangeIndex = SharedDrawIndirectCommandSet.GetCompactedExecutionRangeIndex(
 						activeSlot,
 						lane.ExecutionIndex,
 						page.PageIndex);
-
-					compactParamsWriter.Clear();
-					compactParamsWriter.SetUInt("pageStartCommandIndex", page.PageStartCommandIndex);
-					compactParamsWriter.SetUInt("pageCommandCapacity", page.PageCommandCapacity);
-					compactParamsWriter.SetUInt("laneIndex", (uint)lane.ExecutionIndex);
-					compactParamsWriter.SetUInt("countIndex", (uint)countIndex);
-					compactParamsWriter.SetUInt("recordStrideUints", page.CommandBuffer.RecordStrideInBytes / sizeof(uint));
-					compactParamsWriter.SetUInt(
-						"recordIndexCountUintOffset",
-						page.CommandBuffer.RecordIndexCountOffsetInBytes / sizeof(uint));
-					compactParamsWriter.SetUInt(
-						"activeDrawCommandUpperBound",
+					var request = new NativeIndirectCompactionRequest(
+						page.CommandBuffer,
+						executionRangeBuffer,
+						(uint)rangeIndex,
+						drawArgsBuffer,
+						drawArgsBaseOffsetBytes,
+						drawCommandBuffer,
+						page.PageStartCommandIndex,
+						page.PageCommandCapacity,
+						(uint)lane.ExecutionIndex,
 						_gpuDrawResources.ActiveDrawCommandUpperBound);
-					commandList.SetComputeConstants(compactParamsWriter.RegisterIndex, compactParamsWriter.AsBytes());
 
-					commandList.SetComputeBuffer(0, compactedBuffer);
-					commandList.SetComputeBuffer(1, countBuffer);
-					commandList.SetComputeReadOnlyBuffer(2, templateBuffer);
-					commandList.SetComputeReadOnlyBuffer(3, drawArgsBuffer, drawArgsBaseOffsetBytes);
-					commandList.SetComputeReadOnlyBuffer(4, _gpuDrawResources.DrawCommandBuffer);
+					if (compactionKind == IndirectCompactionKind.NativeCommands)
+					{
+						commandList.RecordNativeIndirectCompaction(request);
+						continue;
+					}
 
-					var (groupCountX, groupCountY, groupCountZ) =
-						threadGroupSize.GetDispatchGroupCount(page.PageCommandCapacity);
-					commandList.Dispatch(groupCountX, groupCountY, groupCountZ);
+					RecordRecordCopyCompaction(commandList, in request);
 				}
 			}
 		}
@@ -1195,15 +1193,81 @@ public sealed class GpuDrawPass
 	}
 
 	/// <summary>
-	/// Compaction is all-or-nothing per command set: a lane left on the full-range path would execute
-	/// stale records that the count buffer no longer describes.
+	/// Dispatches the shared kernel that copies a page's surviving command records into its dense list.
 	/// </summary>
-	private static bool SupportsCompaction(
+	private void RecordRecordCopyCompaction(IGfxCommandList commandList, in NativeIndirectCompactionRequest request)
+	{
+		var templateBuffer = request.CommandBuffer.TemplateRecordBuffer;
+		var compactedBuffer = request.CommandBuffer.CompactedRecordBuffer;
+		if (templateBuffer is null || compactedBuffer is null)
+		{
+			return;
+		}
+
+		var compactParamsWriter = _compactParamsWriter
+		                          ?? throw new InvalidOperationException(
+			                          "GpuDraw compaction reflection writer was not initialized.");
+		var threadGroupSize = _compactThreadGroupSize
+		                      ?? throw new InvalidOperationException(
+			                      "GpuDraw compaction threadgroup size was not initialized.");
+
+		compactParamsWriter.Clear();
+		compactParamsWriter.SetUInt("pageStartCommandIndex", request.PageStartCommandIndex);
+		compactParamsWriter.SetUInt("pageCommandCapacity", request.PageCommandCapacity);
+		compactParamsWriter.SetUInt("laneIndex", request.LaneIndex);
+		compactParamsWriter.SetUInt("executionRangeIndex", request.ExecutionRangeIndex);
+		compactParamsWriter.SetUInt("recordStrideUints", request.CommandBuffer.RecordStrideInBytes / sizeof(uint));
+		compactParamsWriter.SetUInt(
+			"recordIndexCountUintOffset",
+			request.CommandBuffer.RecordIndexCountOffsetInBytes / sizeof(uint));
+		compactParamsWriter.SetUInt("activeDrawCommandUpperBound", request.ActiveDrawCommandUpperBound);
+		commandList.SetComputeConstants(compactParamsWriter.RegisterIndex, compactParamsWriter.AsBytes());
+
+		commandList.SetComputeBuffer(0, compactedBuffer);
+		commandList.SetComputeBuffer(1, request.ExecutionRangeBuffer);
+		commandList.SetComputeReadOnlyBuffer(2, templateBuffer);
+		commandList.SetComputeReadOnlyBuffer(3, request.DrawArgsBuffer, request.DrawArgsBaseOffsetBytes);
+		commandList.SetComputeReadOnlyBuffer(4, request.DrawCommandBuffer);
+
+		var (groupCountX, groupCountY, groupCountZ) =
+			threadGroupSize.GetDispatchGroupCount(request.PageCommandCapacity);
+		commandList.Dispatch(groupCountX, groupCountY, groupCountZ);
+	}
+
+	/// <summary>
+	/// The zeroed range table, kept as a field because it is sized by the lane and page counts and would
+	/// otherwise be a multi-kilobyte stack allocation on every compacting pass.
+	/// </summary>
+	private uint[] RentExecutionRangeReset()
+	{
+		var length = SharedDrawIndirectCommandSet.CompactedExecutionRangeEntryCount *
+		             (IndirectCompactionExecutionRange.StrideInBytes / sizeof(uint));
+		if (_executionRangeReset is null || _executionRangeReset.Length != length)
+		{
+			_executionRangeReset = new uint[length];
+			return _executionRangeReset;
+		}
+
+		Array.Clear(_executionRangeReset);
+		return _executionRangeReset;
+	}
+
+	/// <summary>
+	/// Compaction is all-or-nothing per command set: a lane left on the full-range path would execute
+	/// stale commands that the range table no longer describes. Pages also have to agree on how they
+	/// compact, since one dispatch shape has to cover the whole set.
+	/// </summary>
+	/// <returns>
+	/// Null when the set has no pages to compact, which is not a backend limitation and must not be
+	/// reported as one.
+	/// </returns>
+	private static IndirectCompactionKind? ResolveCompactionKind(
 		SharedDrawIndirectCommandSet commandSet,
 		int activeSlot,
 		ReadOnlySpan<GpuDrawExecutionLaneDefinition> laneDefinitions,
 		Func<GpuDrawExecutionLaneDefinition, bool> laneAvailable)
 	{
+		var resolved = (IndirectCompactionKind?)null;
 		for (var i = 0; i < laneDefinitions.Length; i++)
 		{
 			var lane = laneDefinitions[i];
@@ -1215,14 +1279,17 @@ public sealed class GpuDrawPass
 			var pages = commandSet.GetAllocatedPages(activeSlot, lane.ExecutionIndex);
 			for (var pageIndex = 0; pageIndex < pages.Length; pageIndex++)
 			{
-				if (pages[pageIndex].CommandBuffer.SupportsGpuCompaction == false)
+				var kind = pages[pageIndex].CommandBuffer.CompactionKind;
+				if (kind == IndirectCompactionKind.None || (resolved is { } previous && previous != kind))
 				{
-					return false;
+					return IndirectCompactionKind.None;
 				}
+
+				resolved = kind;
 			}
 		}
 
-		return true;
+		return resolved;
 	}
 
 	private IGfxPipeline EnsureCompactPipeline(IGfxDevice device)
@@ -1573,8 +1640,8 @@ public sealed class GpuDrawPass
 	/// Count buffer for the GBuffer command set when compaction ran this frame, otherwise null so the
 	/// pass falls back to executing its full command range.
 	/// </summary>
-	public IGfxBuffer? GBufferCompactedCommandCountBuffer =>
-		_gbufferCompactionActive ? _gbufferIndirectCommandSet.CompactedCommandCountBuffer : null;
+	public IGfxBuffer? GBufferCompactedExecutionRangeBuffer =>
+		_gbufferCompactionActive ? _gbufferIndirectCommandSet.CompactedExecutionRangeBuffer : null;
 
 	/// <summary>
 	/// Encodes the GBuffer commands and compacts them against the camera cull results. Runs in the cull

--- a/WolfEngine/Rendering/Passes/ShadowMapPass.cs
+++ b/WolfEngine/Rendering/Passes/ShadowMapPass.cs
@@ -193,8 +193,8 @@ public sealed class ShadowMapPass
 			PackedVertexBuffer = gpuDrawResources.PackedMeshVertexBuffer,
 			PackedIndexBuffer = gpuDrawResources.PackedMeshIndexBuffer,
 			PackedVertexStride = gpuDrawResources.PackedMeshVertexStride,
-			CompactedCommandCountBuffer = _compactedExecutionByCascade[cascadeIndex]
-				? commandSet.CompactedCommandCountBuffer
+			CompactedExecutionRangeBuffer = _compactedExecutionByCascade[cascadeIndex]
+				? commandSet.CompactedExecutionRangeBuffer
 				: null
 		};
 	}
@@ -267,12 +267,12 @@ public sealed class ShadowMapPass
 				commandList.BindConstantBuffer(
 					_cameraWriter?.RegisterIndex ?? throw new InvalidOperationException("Shadow camera writer was not initialized."),
 					config.CameraBuffer);
-				if (config.CompactedCommandCountBuffer is { } countBuffer)
+				if (config.CompactedExecutionRangeBuffer is { } executionRangeBuffer)
 				{
 					SharedDrawIndirectExecution.ExecuteCompactedPages(
 						commandList,
 						bucket.IndirectCommandPages.Span,
-						countBuffer,
+						executionRangeBuffer,
 						config.IndirectCommandSlot,
 						bucket.ExecutionIndex,
 						config.FallbackMaxCommandCount);

--- a/WolfEngine/Rendering/Passes/ShadowMapPassConfig.cs
+++ b/WolfEngine/Rendering/Passes/ShadowMapPassConfig.cs
@@ -131,5 +131,5 @@ public struct ShadowMapPassConfig
 	/// Per-page compacted command counts when compaction ran for this cascade, otherwise null, which
 	/// selects the full-range execution path.
 	/// </summary>
-	public IGfxBuffer? CompactedCommandCountBuffer { get; init; }
+	public IGfxBuffer? CompactedExecutionRangeBuffer { get; init; }
 }

--- a/WolfEngine/Rendering/Passes/SharedDrawIndirectCommandSet.cs
+++ b/WolfEngine/Rendering/Passes/SharedDrawIndirectCommandSet.cs
@@ -35,7 +35,7 @@ public sealed class SharedDrawIndirectCommandSet : IDisposable
 
 	private readonly SortedDictionary<uint, IGfxIndirectCommandBuffer>[] _commandPages =
 		new SortedDictionary<uint, IGfxIndirectCommandBuffer>[GpuDrawResources.IndirectCommandBufferSlotCount * GpuDrawExecutionLanes.ExecutionLaneCount];
-	private IGfxBuffer? _compactedCommandCounts;
+	private IGfxBuffer? _compactedExecutionRanges;
 	private readonly ulong[] _appliedStructuralVersions = new ulong[GpuDrawResources.IndirectCommandBufferSlotCount];
 	private readonly uint[] _bindlessEpochs = new uint[GpuDrawResources.IndirectCommandBufferSlotCount];
 	private readonly ulong[] _bindingVersions = new ulong[GpuDrawResources.IndirectCommandBufferSlotCount];
@@ -51,25 +51,25 @@ public sealed class SharedDrawIndirectCommandSet : IDisposable
 	}
 
 	/// <summary>
-	/// Per-page compacted command counts, one entry per (slot, lane, page). Written by the compaction
-	/// dispatch and read by ExecuteIndirect as its count buffer.
+	/// Per-page compacted execution ranges, one entry per (slot, lane, page). Written by the compaction
+	/// dispatch and read by the following execute to bound how many commands it walks.
 	/// </summary>
-	public IGfxBuffer? CompactedCommandCountBuffer => _compactedCommandCounts;
+	public IGfxBuffer? CompactedExecutionRangeBuffer => _compactedExecutionRanges;
 
 	public void EnsureCreated(IGfxDevice device)
 	{
 		ArgumentNullException.ThrowIfNull(device);
-		_compactedCommandCounts ??= device.CreateBuffer(new BufferDescriptor(
-			(ulong)CompactedCommandCountEntryCount * sizeof(uint),
+		_compactedExecutionRanges ??= device.CreateBuffer(new BufferDescriptor(
+			(ulong)CompactedExecutionRangeEntryCount * IndirectCompactionExecutionRange.StrideInBytes,
 			BufferUsage.Indirect,
 			BufferFlags.AllowUnorderedAccess | BufferFlags.AllowShaderResource,
-			name: "SharedDrawCompactedCommandCounts"));
+			name: "SharedDrawCompactedExecutionRanges"));
 	}
 
-	public static int CompactedCommandCountEntryCount =>
+	public static int CompactedExecutionRangeEntryCount =>
 		GpuDrawResources.IndirectCommandBufferSlotCount * GpuDrawExecutionLanes.ExecutionLaneCount * (int)MaxPageCount;
 
-	public static int GetCompactedCommandCountIndex(int slotIndex, int executionLaneIndex, uint pageIndex)
+	public static int GetCompactedExecutionRangeIndex(int slotIndex, int executionLaneIndex, uint pageIndex)
 	{
 		ValidateSlot(slotIndex);
 		ValidateLane(executionLaneIndex);
@@ -198,8 +198,8 @@ public sealed class SharedDrawIndirectCommandSet : IDisposable
 
 	public void Dispose()
 	{
-		(_compactedCommandCounts as IDisposable)?.Dispose();
-		_compactedCommandCounts = null;
+		(_compactedExecutionRanges as IDisposable)?.Dispose();
+		_compactedExecutionRanges = null;
 		for (var i = 0; i < _commandPages.Length; i++)
 		{
 			foreach (var commandBuffer in _commandPages[i].Values)

--- a/WolfEngine/Rendering/Passes/SharedDrawIndirectExecution.cs
+++ b/WolfEngine/Rendering/Passes/SharedDrawIndirectExecution.cs
@@ -60,14 +60,14 @@ internal static class SharedDrawIndirectExecution
 	}
 
 	/// <summary>
-	/// Executes the dense records produced by compaction, taking each page's command count from GPU
-	/// memory. Pages past the active draw range are skipped outright: their count is zero, so the only
-	/// thing executing them would add is a command-processor round trip.
+	/// Executes the dense commands produced by compaction, taking each page's range from GPU memory.
+	/// Pages past the active draw range are skipped outright: their range is empty, so the only thing
+	/// executing them would add is a command-processor round trip.
 	/// </summary>
 	public static void ExecuteCompactedPages(
 		IGfxCommandList commandList,
 		ReadOnlySpan<SharedDrawIndirectCommandPage> pages,
-		IGfxBuffer countBuffer,
+		IGfxBuffer executionRangeBuffer,
 		int slotIndex,
 		int executionLaneIndex,
 		uint commandUpperBound)
@@ -80,14 +80,14 @@ internal static class SharedDrawIndirectExecution
 				continue;
 			}
 
-			var countIndex = SharedDrawIndirectCommandSet.GetCompactedCommandCountIndex(
+			var rangeIndex = SharedDrawIndirectCommandSet.GetCompactedExecutionRangeIndex(
 				slotIndex,
 				executionLaneIndex,
 				page.PageIndex);
 			commandList.ExecuteCompactedIndirectCommandBuffer(
 				page.CommandBuffer,
-				countBuffer,
-				(ulong)countIndex * sizeof(uint));
+				executionRangeBuffer,
+				(ulong)rangeIndex * IndirectCompactionExecutionRange.StrideInBytes);
 		}
 	}
 }

--- a/WolfEngine/Rendering/RenderGraph/RenderGraphFrameBuilder.cs
+++ b/WolfEngine/Rendering/RenderGraph/RenderGraphFrameBuilder.cs
@@ -1901,7 +1901,7 @@ internal sealed class RenderGraphFrameBuilder
 			Buckets = bucketList.ToArray(),
 			FallbackMaxCommandCount = _gpuDrawResources.ActiveDrawCommandUpperBound,
 			IndirectCommandSlot = _gpuDrawResources.ActiveIndirectCommandSlot,
-			CompactedCommandCountBuffer = _gpuDrawPass.GBufferCompactedCommandCountBuffer,
+			CompactedExecutionRangeBuffer = _gpuDrawPass.GBufferCompactedExecutionRangeBuffer,
 			PackedVertexBuffer = _gpuDrawResources.PackedMeshVertexBuffer,
 			PackedIndexBuffer = _gpuDrawResources.PackedMeshIndexBuffer,
 			PackedVertexStride = _gpuDrawResources.PackedMeshVertexStride,

--- a/WolfEngine/Shaders/Metal/gpu_draw_compact_icb.metal
+++ b/WolfEngine/Shaders/Metal/gpu_draw_compact_icb.metal
@@ -1,0 +1,107 @@
+// Compacts a page of indirect draw commands down to the draws the cull pass marked visible, so the
+// following execute walks only what survived culling instead of every draw slot in the scene.
+//
+// This is the Metal counterpart to gpu_draw_compact.compute.slang and applies exactly the same
+// visibility rules. It cannot share that source: a Metal indirect command buffer is an opaque object
+// rather than a buffer of command records, so the surviving commands are moved with the GPU-side
+// copy_command intrinsic instead of a raw record copy. Keep the two kernels' rules in step.
+//
+// The structs below mirror draw_data.slang, and MetalIndirectCompactionKernel asserts that they still
+// match the C# layouts they are read through.
+
+#include <metal_stdlib>
+#include <metal_command_buffer>
+
+using namespace metal;
+
+struct CompactionCommandBuffers
+{
+	command_buffer source [[id(0)]];
+	command_buffer destination [[id(1)]];
+};
+
+struct CompactionParams
+{
+	uint pageStartCommandIndex;
+	uint pageCommandCapacity;
+	uint laneIndex;
+	uint executionRangeIndex;
+	uint activeDrawCommandUpperBound;
+};
+
+struct GpuDrawCommand
+{
+	uint instanceHandle;
+	uint drawHandle;
+	uint flags;
+	uint pad0;
+};
+
+struct GpuDrawArgs
+{
+	uint indexCount;
+	uint instanceCount;
+	uint startIndex;
+	int baseVertex;
+	uint startInstance;
+	uint pad0;
+	uint pad1;
+	uint pad2;
+};
+
+constant uint kDrawFlagActive = 1u;
+constant uint kDrawFlagBucketShift = 1u;
+constant uint kDrawFlagBucketMask = 0x7FFFFFFFu;
+
+kernel void CSCompactIndirectCommands(
+	device const CompactionCommandBuffers& commandBuffers [[buffer(0)]],
+	device atomic_uint* executionRanges [[buffer(1)]],
+	device const GpuDrawArgs* drawArgs [[buffer(2)]],
+	device const GpuDrawCommand* drawCommands [[buffer(3)]],
+	constant CompactionParams& params [[buffer(4)]],
+	uint pageCommandIndex [[thread_position_in_grid]])
+{
+	if (pageCommandIndex >= params.pageCommandCapacity)
+	{
+		return;
+	}
+
+	uint drawId = params.pageStartCommandIndex + pageCommandIndex;
+	if (drawId >= params.activeDrawCommandUpperBound)
+	{
+		return;
+	}
+
+	GpuDrawCommand command = drawCommands[drawId];
+	if ((command.flags & kDrawFlagActive) == 0u)
+	{
+		return;
+	}
+
+	// Every lane allocates a page over the same draw id range, and the lanes that do not own this draw
+	// hold a reset command here. Emitting only from the owning lane keeps the other lanes' compacted
+	// lists free of the resets they would otherwise walk past at execute time.
+	uint bucketIndex = (command.flags >> kDrawFlagBucketShift) & kDrawFlagBucketMask;
+	if (bucketIndex != params.laneIndex)
+	{
+		return;
+	}
+
+	if (drawArgs[drawId].instanceCount == 0u)
+	{
+		return;
+	}
+
+	// Entries are execution ranges of { location, length }. Compacted commands always start at zero, so
+	// only the length moves, and it doubles as the allocator for the dense destination slots.
+	device atomic_uint* length = &executionRanges[(params.executionRangeIndex * 2u) + 1u];
+	uint destinationIndex = atomic_fetch_add_explicit(length, 1u, memory_order_relaxed);
+	if (destinationIndex >= params.pageCommandCapacity)
+	{
+		return;
+	}
+
+	render_command destination(commandBuffers.destination, destinationIndex);
+	render_command source(commandBuffers.source, pageCommandIndex);
+	destination.copy_command(source);
+}

--- a/WolfEngine/Shaders/gpu_draw_compact.compute.slang
+++ b/WolfEngine/Shaders/gpu_draw_compact.compute.slang
@@ -15,7 +15,7 @@ cbuffer CompactParams : register(b12)
     uint pageStartCommandIndex;
     uint pageCommandCapacity;
     uint laneIndex;
-    uint countIndex;
+    uint executionRangeIndex;
     uint recordStrideUints;
     uint recordIndexCountUintOffset;
     uint activeDrawCommandUpperBound;
@@ -23,7 +23,9 @@ cbuffer CompactParams : register(b12)
 };
 
 RWStructuredBuffer<uint> g_DestinationRecords : register(u0);
-RWStructuredBuffer<uint> g_Counts : register(u1);
+// Entries are execution ranges of { location, length }. Compacted records always start at zero, so
+// only the length moves, and it doubles as the allocator for the dense destination slots.
+RWStructuredBuffer<uint> g_ExecutionRanges : register(u1);
 
 StructuredBuffer<uint> g_SourceRecords : register(t2);
 // Bound with the view's base offset already applied, so this indexes by draw id directly.
@@ -74,7 +76,7 @@ void CSCompact(uint3 dispatchThreadId : SV_DispatchThreadID)
     }
 
     uint destinationIndex;
-    InterlockedAdd(g_Counts[countIndex], 1, destinationIndex);
+    InterlockedAdd(g_ExecutionRanges[(executionRangeIndex * 2) + 1], 1, destinationIndex);
     if (destinationIndex >= pageCommandCapacity)
     {
         return;

--- a/WolfEngine/WolfEngine.csproj
+++ b/WolfEngine/WolfEngine.csproj
@@ -24,6 +24,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- The Metal backend compiles this at runtime, so it ships inside the assembly rather than
+             going through the Slang shader pipeline the rest of the shaders use. -->
+        <EmbeddedResource Include="Shaders\Metal\gpu_draw_compact_icb.metal" />
+    </ItemGroup>
+
+    <ItemGroup>
         <None Update="Assets\Monkey.obj">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>


### PR DESCRIPTION
Overhauls draw compaction so it works on both DX12 and Metal.

Validated on both platforms.